### PR TITLE
fix(trainer): remove redundant brackets in tensor construction

### DIFF
--- a/agentevolver/module/trainer/ae_ray_trainer.py
+++ b/agentevolver/module/trainer/ae_ray_trainer.py
@@ -201,7 +201,7 @@ def compute_grpo_outcome_advantage(
                 id2std[idx] = torch.tensor(1.0)
             elif len(id2score[idx]) > 1:
                 id2mean[idx] = torch.mean(torch.tensor(id2score[idx]))
-                id2std[idx] = torch.std(torch.tensor([id2score[idx]]))
+                id2std[idx] = torch.std(torch.tensor(id2score[idx]))
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):


### PR DESCRIPTION
## Description

This PR fixes an incorrect tensor construction in [`ae_ray_trainer.py`](AgentEvolver/agentevolver/module/trainer/ae_ray_trainer.py).

Previously, the standard deviation calculation wrapped the score list in an extra pair of brackets:

```python
torch.tensor([id2score[idx]])
```

Because `id2score[idx]` is already a 1D list/array, this created an unintended 2D tensor with shape `(1, N)` instead of the expected `(N,)`. It also caused inconsistency with the mean calculation directly above it.

The fix removes the redundant brackets:

```python
torch.tensor(id2score[idx])
```

### How to test

Run a training step and confirm that the resulting standard deviation tensor is 1D and no longer triggers unnecessary dimension handling.

## Checklist

- [x] All tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been reviewed (no updates required)
- [x] Code is ready for review