### PR TITLE
Fix: pass config.data to FullDataset so dataset-level keys (e.g. max_prompt_length) are available

### DIFF
--- a/agentevolver/module/trainer/ae_ray_trainer.py
+++ b/agentevolver/module/trainer/ae_ray_trainer.py
@@ -549,7 +549,7 @@ class AgentEvolverRayPPOTrainer(RayPPOTrainer):
             self.train_task_manager._reward_config,
             self.config.task_manager.train_data_path,
             tokenizer=self.tokenizer,
-            config=self.config,
+            config=self.config.data,
             processor=self.processor,
         )
         self.val_dataset = FullDataset(
@@ -558,7 +558,7 @@ class AgentEvolverRayPPOTrainer(RayPPOTrainer):
             self.val_task_manager._reward_config,
             cache_path=None,
             tokenizer=self.tokenizer,
-            config=self.config,
+            config=self.config.data,
             processor=self.processor,
         )
 


### PR DESCRIPTION
## Description

Fixed incorrect config parameter passed to `FullDataset` initialization in `ae_ray_trainer.py`, which prevented dataset-level configuration fields like `max_prompt_length` from being accessible.

### Background

When building train/validation datasets in `ae_ray_trainer.py` (lines 546-563), the top-level `self.config` was passed to `FullDataset`. However, dataset-related fields such as `max_prompt_length` and `max_response_length` are defined under `config.data` in the hierarchical veRL-style config structure. This caused `FullDataset` and its downstream `to_rl_dataset()` function to fail when accessing these fields, leading to unexpected behavior during dataset initialization.

### Changes

Changed `FullDataset` initialization to pass `self.config.data` instead of `self.config`:

```python
# agentevolver/module/trainer/ae_ray_trainer.py:546-563
self.train_dataset = FullDataset(..., config=self.config.data, ...)
self.val_dataset = FullDataset(..., config=self.config.data, ...)
```

### How to Test

1. Run dataset initialization logic that triggers `FullDataset` construction (e.g., start a training workflow).
2. Verify that `max_prompt_length`, `max_response_length`, and other dataset-level configuration fields are correctly loaded and accessible within `FullDataset` and its downstream processing functions.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [N/A]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review