### PR TITLE
Fix: read task_train_mode from metadata in EnvManager.get_extra

### DIFF
--- a/agentevolver/module/env_manager/env_manager.py
+++ b/agentevolver/module/env_manager/env_manager.py
@@ -400,7 +400,7 @@ class ParallelEnvManager(object):
         """
         extras = {
             "add_exp": cmt.metadata.get("add_exp", None),  # ⭐ Retrieves the 'add_exp' value from metadata
-            "task_train_expmode": cmt.metadata.get("task_train_exp_mode", None),  # ⭐ Retrieves the 'task_train_exp_mode' value from metadata
+            "task_train_expmode": cmt.metadata.get("task_train_mode", None),  # ⭐ Retrieves the 'task_train_mode' value from metadata
             "experience_list": cmt.metadata.get("experience_list", [])  # ⭐ Retrieves the 'experience' list from metadata
         }
         return extras


### PR DESCRIPTION
## Description

Fixed incorrect metadata key name in `EnvManager.get_extra()` that caused `task_train_expmode` to always be `None` in sample extras, breaking experience mask generation for hybrid experience training.

### Background

In the Hybrid Experience Training workflow, `task_train_mode` is written to trajectory metadata in `AgentFlow.execute()` (line 79) to indicate whether samples should retain or discard experience context. However, `EnvManager.get_extra()` attempted to read `task_train_exp_mode` (which is never written), causing `task_train_expmode` to always be `None`. This prevents correct generation of experience masks needed to distinguish on-policy vs off-policy samples during training.

### Changes

Changed `EnvManager.get_extra()` (line 403) to use the correct metadata key:

```python
"task_train_expmode": cmt.metadata.get("task_train_mode", None)  # was: "task_train_exp_mode"
```

### How to Test

1. Run a training workflow with hybrid experience training enabled (`exp_manager.train_sample_mode` set to `"hybrid"` or non-`"alldiscard"` value), or any workflow that triggers `EnvManager.trajectories_to_samples()`.
2. Verify that `sample.extras["task_train_expmode"]` is not `None` and correctly reflects the trajectory's training mode (`"keep"` or `"discard"`).
3. Verify that experience masks are correctly generated: when `add_exp=True` and `task_train_expmode="discard"`, the corresponding positions in `exp_mask` should be 1; otherwise 0.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [N/A]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review