### PR TITLE
[fix] Fix generate_train_parquet config format compatibility issues

### DIFF
--- a/games/agent_factory.py
+++ b/games/agent_factory.py
@@ -162,7 +162,7 @@ def create_memory_from_config(
         return InMemoryMemory()
     
     memory_type = memory_config.get('type', 'InMemoryMemory')
-    memory_kwargs = memory_config.get('kwargs', {})
+    memory_kwargs = memory_config.get('kwargs') or {}
     
     # Try to import from agentscope.memory first
     try:
@@ -250,7 +250,7 @@ def create_formatter_from_config(
         formatter_kwargs = {}
     elif isinstance(formatter_config, dict):
         formatter_type = formatter_config.get('type', 'SecureMultiAgentFormatter')
-        formatter_kwargs = formatter_config.get('kwargs', {}).copy()
+        formatter_kwargs = (formatter_config.get('kwargs') or {}).copy()
     else:
         # If formatter_config is not a dict, use defaults
         formatter_type = 'SecureMultiAgentFormatter'
@@ -380,7 +380,7 @@ def create_agent_from_config(
     if 'type' not in agent_config:
         raise ValueError("agent_config must contain 'type' field")
     
-    if 'kwargs' not in agent_config:
+    if 'kwargs' not in agent_config or agent_config['kwargs'] is None:
         agent_config['kwargs'] = {}
     
     # Load agent class

--- a/games/games/avalon/configs/arena_config.yaml
+++ b/games/games/avalon/configs/arena_config.yaml
@@ -35,5 +35,5 @@ default_role:
     stream: false
   agent:
     type: ThinkingReActAgent
-    kwargs: {}
+    kwargs: null
 

--- a/games/games/avalon/configs/default_config.yaml
+++ b/games/games/avalon/configs/default_config.yaml
@@ -16,7 +16,7 @@ default_role:
     stream: false
   agent:
     type: ThinkingReActAgent
-    kwargs: {}
+    kwargs: null
 
 # Default game configuration
 game:

--- a/games/games/diplomacy/configs/arena_config.yaml
+++ b/games/games/diplomacy/configs/arena_config.yaml
@@ -49,5 +49,5 @@ default_role:
     kwargs:
       memory:
         type: SlidingWindowMemory
-        kwargs: {}
+        kwargs: null
 

--- a/games/games/diplomacy/configs/default_config.yaml
+++ b/games/games/diplomacy/configs/default_config.yaml
@@ -15,7 +15,7 @@ default_role:
     kwargs:
       memory:
         type: SlidingWindowMemory
-        kwargs: {}
+        kwargs: null
 
 # Default game configuration
 game:

--- a/games/generate_train_parquet.py
+++ b/games/generate_train_parquet.py
@@ -54,16 +54,17 @@ def generate_train_tasks_parquet(
         task_id_prefix = f"{env_type}_train"
     
     # Extract game configuration for metadata
-    # For avalon: roles with trainable flag
-    # For diplomacy: models with trainable flag
+    # Structure should match what's expected by the training pipeline
     game_config = {
-        'default_model': base_config.get('default_model', {}),
         'game': base_config.get('game', {}),
     }
     
-    # Handle role/model configuration based on game type
+    # Extract default_role configuration (used as default for all roles)
+    if 'default_role' in base_config:
+        game_config['default_role'] = base_config.get('default_role', {})
+    
+    # Extract roles with trainable flag (Avalon-style configuration)
     if 'roles' in base_config:
-        # Avalon-style: roles configuration
         roles_config = {}
         for role_name, role_cfg in base_config.get('roles', {}).items():
             if isinstance(role_cfg, dict) and role_cfg.get('trainable', False):


### PR DESCRIPTION
## Description

Fix generate_train_parquet config format compatibility issues

This commit fixes several compatibility issues between generate_train_parquet.py and the game configuration format:

Config field name mismatch: Changed from default_model to default_role to match the actual config structure in default_config.yaml and train_config.yaml

PyArrow empty struct type error: Fixed “Cannot write struct type ‘kwargs’ with no child field to Parquet” error by changing empty kwargs: {} to kwargs: null in all game config files:

games/games/avalon/configs/default_config.yaml
games/games/avalon/configs/arena_config.yaml
games/games/diplomacy/configs/default_config.yaml
games/games/diplomacy/configs/arena_config.yaml
Agent factory null handling: Updated agent_factory.py to properly handle kwargs: null values by converting them to empty dictionaries:

Added null check in create_agent_from_config()
Fixed formatter_kwargs and memory_kwargs to handle None values
These changes ensure that:

Training task generation correctly extracts config from YAML files
Parquet files can be written without PyArrow struct type errors
Agent creation works correctly with null kwargs values

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review