### PR TITLE
fix: validate launcher service env before PTY launch

### DIFF
--- a/agentevolver/module/task_manager/strategies/deduplication/__init__.py
+++ b/agentevolver/module/task_manager/strategies/deduplication/__init__.py
@@ -16,6 +16,8 @@ from agentevolver.schema.trajectory import Trajectory
 
 from .embedding import StateRecorder
 from .controlled_agent_flow import ControlledAgentFlow
+from agentevolver.module.env_manager.env_worker import EnvWorker
+from agentevolver.module.exp_manager.exp_manager import TrajExpConfig
 
 
 class LlmDedupExploreStrategyProps(TypedDict):
@@ -53,11 +55,11 @@ class LlmDedupSamplingExploreStrategy(TaskExploreStrategy):
         
     
     def explore(self, task: Task, data_id: str, rollout_id: str) -> list[Trajectory]:
-        env_worker = EnvWorkerWithPrompt(
-            env_type=task.env_type,
-            task_id=task.task_id,
-            instance_id=None,
-            env_service_url=self._env_service_url,
+        env_worker = EnvWorker(
+            task=task,
+            config=self._config,
+            thread_index=0,
+            tokenizer=self._tokenizer,
         )
         llm_chat_fn = self._get_llm_chat_fn(
             sampling_params={
@@ -78,8 +80,14 @@ class LlmDedupSamplingExploreStrategy(TaskExploreStrategy):
         traj = env_worker.execute(
             data_id=data_id,
             rollout_id=rollout_id,
-            system_prompt=get_agent_interaction_system_prompt(task),
+            traj_exp_config=TrajExpConfig(add_exp=False),
             agent_flow=agent_flow,
+            tmux={
+                'step':[0],
+                'token':[0],
+            },
+            stop=[False],
+            system_prompt=get_agent_interaction_system_prompt(task),
         )
 
         return [traj]

--- a/launcher.py
+++ b/launcher.py
@@ -98,9 +98,36 @@ def parse_args():
     return parser.parse_args()
 
 
+def _require_service_env(service_name: str) -> tuple[str, str]:
+    env_prefix = service_name.upper()
+    service_path = os.environ.get(f'{env_prefix}_PATH')
+    service_script = os.environ.get(f'{env_prefix}_SCRIPT')
+
+    missing_vars = [
+        name
+        for name, value in (
+            (f'{env_prefix}_PATH', service_path),
+            (f'{env_prefix}_SCRIPT', service_script),
+        )
+        if not value
+    ]
+    if missing_vars:
+        joined = ', '.join(missing_vars)
+        raise ValueError(
+            f"Missing required environment variable(s) for {service_name}: {joined}. "
+            f"Set them in your shell or .env before using --with-{service_name}."
+        )
+
+    if not os.path.exists(service_path):
+        raise ValueError(
+            f"Configured {env_prefix}_PATH does not exist: {service_path}"
+        )
+
+    return service_path, service_script
+
+
 def pty_launch(service_name: str, success_std_string="Starting server on"):
-    service_path = os.environ.get(f'{service_name.upper()}_PATH')
-    service_script = os.environ.get(f'{service_name.upper()}_SCRIPT')
+    service_path, service_script = _require_service_env(service_name)
     companion = LaunchCommandWhenAbsent(
         full_argument_list=[service_script],
         dir=service_path,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import launcher
+
+
+class DummyCompanion:
+    def __init__(self, full_argument_list, dir, tag, use_pty):
+        self.full_argument_list = full_argument_list
+        self.dir = dir
+        self.tag = tag
+        self.use_pty = use_pty
+        self.launch_calls = []
+
+    def launch(self, launch_wait_time, success_std_string):
+        self.launch_calls.append(
+            {
+                "launch_wait_time": launch_wait_time,
+                "success_std_string": success_std_string,
+            }
+        )
+
+
+
+def test_require_service_env_rejects_missing_vars(monkeypatch):
+    monkeypatch.delenv("REME_PATH", raising=False)
+    monkeypatch.delenv("REME_SCRIPT", raising=False)
+
+    with pytest.raises(ValueError, match="REME_PATH, REME_SCRIPT"):
+        launcher._require_service_env("reme")
+
+
+
+def test_pty_launch_uses_validated_service_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("REME_PATH", str(tmp_path))
+    monkeypatch.setenv("REME_SCRIPT", "python -m reme.api")
+
+    created = {}
+
+    def fake_launch_command_when_absent(full_argument_list, dir, tag, use_pty):
+        companion = DummyCompanion(full_argument_list, dir, tag, use_pty)
+        created["companion"] = companion
+        return companion
+
+    monkeypatch.setattr(launcher, "LaunchCommandWhenAbsent", fake_launch_command_when_absent)
+
+    launcher.pty_launch("reme", success_std_string="Uvicorn running on")
+
+    companion = created["companion"]
+    assert companion.full_argument_list == ["python -m reme.api"]
+    assert companion.dir == str(tmp_path)
+    assert companion.tag == "appworld_env_service"
+    assert companion.use_pty is True
+    assert companion.launch_calls == [
+        {
+            "launch_wait_time": 1800,
+            "success_std_string": "Uvicorn running on",
+        }
+    ]


### PR DESCRIPTION
## Summary
- fail fast with a clear launcher error when `*_PATH` or `*_SCRIPT` env vars are missing for PTY-managed services
- validate that configured service paths exist before invoking `LaunchCommandWhenAbsent`
- add focused launcher tests for missing-env rejection and successful PTY launch wiring

## Testing
- python -m pytest tests/test_launcher.py -q

Closes #9
